### PR TITLE
Config update (v1.1.0)

### DIFF
--- a/AnchorChain.Tests/ConfigLoading.cs
+++ b/AnchorChain.Tests/ConfigLoading.cs
@@ -50,7 +50,7 @@ public class Config03 : IAnchorChainMod
 }
 
 
-[ACPlugin("io.github.seapower-modders.AnchorChainConfigI04", "Config 04", "1.0")]
+[ACPlugin("io.github.seapower-modders.AnchorChainConfig04", "Config 04", "1.0")]
 [ACConfig(required: true)]
 public class Config04 : IAnchorChainMod
 {
@@ -59,5 +59,28 @@ public class Config04 : IAnchorChainMod
 		Debug.LogWarning("Config info 04 loaded.");
 	}
 }
+
+
+[ACPlugin("io.github.seapower-modders.AnchorChainConfig05", "Config 05", "1.0")]
+[ACConfig(required: true)]
+public class Config05 : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 05 loaded.");
+	}
+}
+
+
+[ACPlugin("io.github.seapower-modders.AnchorChainConfig06", "Config 06", "1.0")]
+[ACConfig(required: true)]
+public class Config06 : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 06 loaded.");
+	}
+}
+
 
 #endif

--- a/AnchorChain.Tests/ConfigLoading.cs
+++ b/AnchorChain.Tests/ConfigLoading.cs
@@ -1,0 +1,63 @@
+﻿// Uncomment following line to activate CLO tests
+#define Config
+#if Config
+
+using UnityEngine;
+
+
+namespace AnchorChain.Tests;
+
+[ACPlugin("io.github.seapower-modders.AnchorChainConfigInfo", "Config Info", "1.0")]
+public class ConfigInfo : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 01, 02, and 03 should load.");
+	}
+}
+
+
+[ACPlugin("io.github.seapower-modders.AnchorChainConfig01", "Config 01", "1.0")]
+[ACConfig]
+public class Config01 : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 01 loaded.");
+	}
+}
+
+
+[ACPlugin("io.github.seapower-modders.AnchorChainConfig02", "Config 02", "1.0")]
+[ACConfig]
+public class Config02 : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 02 loaded.");
+	}
+}
+
+
+[ACPlugin("io.github.seapower-modders.AnchorChainConfig03", "Config 03", "1.0")]
+[ACConfig(required: true)]
+public class Config03 : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 03 loaded.");
+	}
+}
+
+
+[ACPlugin("io.github.seapower-modders.AnchorChainConfigI04", "Config 04", "1.0")]
+[ACConfig(required: true)]
+public class Config04 : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 04 loaded.");
+	}
+}
+
+#endif

--- a/AnchorChain.Tests/ConfigLoading.cs
+++ b/AnchorChain.Tests/ConfigLoading.cs
@@ -12,11 +12,12 @@ public class ConfigInfo : IAnchorChainMod
 {
 	public void TriggerEntryPoint()
 	{
-		Debug.LogWarning("Config info 01, 02, and 03 should load.");
+		Debug.LogWarning("Config info 01, 03, and 04 should load.");
 	}
 }
 
 
+// Test required config existing
 [ACPlugin("io.github.seapower-modders.AnchorChainConfig01", "Config 01", "1.0")]
 [ACConfig]
 public class Config01 : IAnchorChainMod
@@ -28,6 +29,7 @@ public class Config01 : IAnchorChainMod
 }
 
 
+// Test required config not existing
 [ACPlugin("io.github.seapower-modders.AnchorChainConfig02", "Config 02", "1.0")]
 [ACConfig]
 public class Config02 : IAnchorChainMod
@@ -39,8 +41,9 @@ public class Config02 : IAnchorChainMod
 }
 
 
+// Test non-required config existing
 [ACPlugin("io.github.seapower-modders.AnchorChainConfig03", "Config 03", "1.0")]
-[ACConfig(required: true)]
+[ACConfig(required: false)]
 public class Config03 : IAnchorChainMod
 {
 	public void TriggerEntryPoint()
@@ -50,8 +53,9 @@ public class Config03 : IAnchorChainMod
 }
 
 
+// Test non-required config not existing
 [ACPlugin("io.github.seapower-modders.AnchorChainConfig04", "Config 04", "1.0")]
-[ACConfig(required: true)]
+[ACConfig(required: false)]
 public class Config04 : IAnchorChainMod
 {
 	public void TriggerEntryPoint()
@@ -61,8 +65,9 @@ public class Config04 : IAnchorChainMod
 }
 
 
+// Test config missing section
 [ACPlugin("io.github.seapower-modders.AnchorChainConfig05", "Config 05", "1.0")]
-[ACConfig(required: true)]
+[ACConfig()]
 public class Config05 : IAnchorChainMod
 {
 	public void TriggerEntryPoint()
@@ -72,13 +77,26 @@ public class Config05 : IAnchorChainMod
 }
 
 
+// Test config missing key
 [ACPlugin("io.github.seapower-modders.AnchorChainConfig06", "Config 06", "1.0")]
-[ACConfig(required: true)]
+[ACConfig()]
 public class Config06 : IAnchorChainMod
 {
 	public void TriggerEntryPoint()
 	{
 		Debug.LogWarning("Config info 06 loaded.");
+	}
+}
+
+
+// Test resetting value
+[ACPlugin("io.github.seapower-modders.AnchorChainConfig07", "Config 07", "1.0")]
+[ACConfig()]
+public class Config07 : IAnchorChainMod
+{
+	public void TriggerEntryPoint()
+	{
+		Debug.LogWarning("Config info 07 loaded.");
 	}
 }
 

--- a/AnchorChain.Tests/ImpliedDependency.cs
+++ b/AnchorChain.Tests/ImpliedDependency.cs
@@ -1,5 +1,5 @@
 ﻿// Uncomment following line to activate SD tests
-#define ID
+// #define ID
 #if ID
 
 using UnityEngine;

--- a/AnchorChain.Tests/LoadOrder.cs
+++ b/AnchorChain.Tests/LoadOrder.cs
@@ -1,5 +1,5 @@
 ﻿// Uncomment following line to activate SD tests
-#define LO
+// #define LO
 #if LO
 
 using UnityEngine;

--- a/AnchorChain.Tests/StrictDependency.cs
+++ b/AnchorChain.Tests/StrictDependency.cs
@@ -1,5 +1,5 @@
 ﻿// Uncomment following line to activate SD tests
-#define SD
+// #define SD
 #if SD
 
 using UnityEngine;

--- a/AnchorChain/AnchorChain.csproj
+++ b/AnchorChain/AnchorChain.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <LangVersion>12.0</LangVersion>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AnchorChain/AnchorChain.csproj
+++ b/AnchorChain/AnchorChain.csproj
@@ -21,6 +21,10 @@
       <HintPath>..\Dll\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Noesis.NoesisGUI">
+      <HintPath>..\Dll\Noesis.NoesisGUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Seapower-Scripts">
       <HintPath>..\Dll\Seapower-Scripts.dll</HintPath>
       <Private>False</Private>

--- a/AnchorChain/Main.cs
+++ b/AnchorChain/Main.cs
@@ -234,6 +234,7 @@ namespace AnchorChain
 
             // Ensure config validity
             if (!ConfigIsRecent(userIni, defaultIni)) {
+                Logger.LogInfo($"Plugin missing section key: {pluginData.Name} ({pluginData.GUID})");
                 if (!WriteNewConfig(pluginData, userPath, defaultPath)) {
                     if (configData.Required) {
                         return false;

--- a/AnchorChain/Main.cs
+++ b/AnchorChain/Main.cs
@@ -3,354 +3,349 @@ using BepInEx;
 using SeaPower;
 using System.Reflection;
 
-namespace AnchorChain
+namespace AnchorChain;
+
+
+[BepInPlugin("io.github.seapower_modders.anchorchain", "AnchorChain", "1.1.0")]
+public class AnchorChainLoader : BaseUnityPlugin, Preloader.IPluginLoader
 {
-    [BepInPlugin("io.github.seapower_modders.anchorchain", "AnchorChain", "1.1.0")]
-    public class AnchorChainLoader : BaseUnityPlugin, Preloader.IPluginLoader
-    {
-        private static Dictionary<string, HashSet<ACPlugin>> _postLoadsCache = new();
-        private static HashSet<DirectoryInfo> _allDirectories = new();
-        private static string _configPath = string.Empty;
-
-
-        public void LoadPlugins()
-        {
-            Dictionary<string, (ACPlugin, IAnchorChainMod)> recognizedPlugins = new();
-            IniHandler userIni = new();
-            IniHandler defaultIni = new();
-
-            if (!Setup()) {
-                Logger.LogError($"Anchor Chain setup failed, aborting load.");
-                return;
-            }
-
-            // First pass, registering plugin classes, configs, dependencies, and plugins to preload
-            foreach (DirectoryInfo dir in _allDirectories) {
-                string possiblePath = Path.Combine(dir.FullName);
-
-                string[] dllFiles = Directory.GetFiles(possiblePath, "*.dll", SearchOption.AllDirectories);
-
-                foreach (string asmPath in dllFiles) {
-                    try {
-                        Assembly loaded = Assembly.LoadFile(asmPath);
-                        Logger.LogInfo("Loaded assembly " + loaded.FullName);
-
-                        foreach (Type plugin in (from x in loaded.GetExportedTypes()
-                                     where x.GetInterfaces().Contains(typeof(IAnchorChainMod))
-                                     select x))
-                        {
-                            // All valid plugins should be annotated with ACPlugin
-                            ACPlugin pluginData = (ACPlugin)Attribute.GetCustomAttribute(plugin, typeof(ACPlugin));
-                            if (pluginData is null) continue;
-
-                            ACConfig configData = (ACConfig)Attribute.GetCustomAttribute(plugin, typeof(ACConfig));
-
-                            if (configData is not null && !LoadConfigs(pluginData, configData, userIni, defaultIni)) continue;
-
-                            // Set dependencies and incompatibilities
-                            pluginData.Dependencies =
-                                new(Attribute.GetCustomAttributes(plugin, typeof(ACDependency)).Cast<ACDependency>() ?? []);
-                            pluginData.Incompatibilities =
-                                new(Attribute.GetCustomAttributes(plugin, typeof(ACIncompatibility)).Cast<ACIncompatibility>() ?? []);
-
-                            // Ensure all preloads and postloads are dependencies
-                            pluginData.Dependencies.UnionWith(pluginData.Before.Select(x => new ACDependency(x, null, null)));
-                            pluginData.Dependencies.UnionWith(pluginData.After.Select(x => new ACDependency(x, null, null)));
-
-                            if (!recognizedPlugins.TryAdd(pluginData.GUID, (pluginData, (IAnchorChainMod)Activator.CreateInstance(plugin)))) {
-                                Logger.LogWarning($"Attempted to load a duplicate plugin: {pluginData.Name} ({pluginData.GUID})");
-                            }
-                        }
-                    }
-                    catch (Exception ex) {
-                        Logger.LogWarning("Error loading assembly at path " + asmPath + ": " + ex);
-                    }
-                }
-            }
-
-            // Ensure all dependencies are met, and remove plugins missing dependencies
-            while (true) {
-                HashSet<ACPlugin> toRemove = new();
-
-                foreach ((ACPlugin pluginData, IAnchorChainMod _) in recognizedPlugins.Values) {
-                    foreach (ACDependency dependency in pluginData.Dependencies) {
-                        if (!recognizedPlugins.ContainsKey(dependency.GUID)) {
-                            Logger.LogWarning(
-                                $"Skipping mod \"{pluginData.Name}\" ({pluginData.GUID}); missing dependency \"{dependency.GUID}\"");
-                            toRemove.Add(pluginData);
-                            break;
-                        }
-                        if (!dependency.Contains(recognizedPlugins[dependency.GUID].Item1.Version)) {
-                            Logger.LogWarning(
-                                $"Skipping mod \"{pluginData.Name}\" ({pluginData.GUID}); mis-versioned dependency \"{dependency.GUID}\"");
-                            toRemove.Add(pluginData);
-                            break;
-                        }
-                    }
-
-                    foreach (ACIncompatibility incompatibility in pluginData.Incompatibilities) {
-                        if (recognizedPlugins.ContainsKey(incompatibility.GUID)) {
-                            Logger.LogWarning(
-                                $"Skipping mod \"{pluginData.Name}\" ({pluginData.GUID}); detected incompatible mod \"{incompatibility.GUID}\"");
-                        }
-                        toRemove.Add(pluginData);
-                        break;
-                    }
-                }
-
-                if (toRemove.Count == 0) {
-                    break;
-                }
-
-                foreach (ACPlugin pluginData in toRemove) {
-                    recognizedPlugins.Remove(pluginData.GUID);
-                }
-            }
-
-            // Cast all preloads to postloads and postloads to preloads
-            foreach ((ACPlugin pluginData, IAnchorChainMod _) in recognizedPlugins.Values) {
-                foreach (string plugin in pluginData.Before) {
-                    recognizedPlugins[plugin].Item1.After.Add(pluginData.GUID);
-                }
-
-                foreach (string plugin in pluginData.After) {
-                    recognizedPlugins[plugin].Item1.Before.Add(pluginData.GUID);
-                }
-            }
-
-            // Screen for circular post loads
-            bool circularLoad = false;
-            foreach ((ACPlugin pluginData, IAnchorChainMod _) in recognizedPlugins.Values) {
-                HashSet<ACPlugin> postLoads = FindAllPostLoads(pluginData, recognizedPlugins, new());
-                if (postLoads.Contains(pluginData)) {
-                    Logger.LogError($"Aborting chainload; circular load order chain detected: {postLoads}");
-                    circularLoad = true;
-                }
-            }
-            if (circularLoad) { return; }
-
-            // Get first "level" of plugins with no preloads
-            HashSet<string> currentLevel = (from x in recognizedPlugins.Values where x.Item1.After.Count == 0 select x.Item1.GUID).ToHashSet() ?? new();
-            HashSet<string> alreadyLoaded = new();
-
-            while (true) {
-                if (currentLevel.Count == 0) { break; }
-
-                bool loadedOne = false;
-                HashSet<string> toLoad = new();
-                foreach (string guid in currentLevel) {
-                    (ACPlugin pluginData, IAnchorChainMod plugin) = recognizedPlugins[guid];
-                    if (pluginData.After.IsSubsetOf(alreadyLoaded)) {
-                        try {
-                            plugin.TriggerEntryPoint();
-                            Logger.LogInfo($"Loaded plugin {pluginData.Name} ({pluginData.GUID})");
-                            toLoad.UnionWith(pluginData.Before);
-                            alreadyLoaded.Add(pluginData.GUID);
-                            loadedOne = true;
-                        }
-                        catch (Exception e) {
-                            Logger.LogError($"Error loading plugin {pluginData.Name} ({pluginData.GUID}): {e}");
-                        }
-                    }
-                }
-
-                currentLevel.UnionWith(toLoad);
-                currentLevel.RemoveWhere(x => alreadyLoaded.Contains(x));
-
-                if (!loadedOne) {
-                    Logger.LogError($"Aborting chainload; unable to load any more plugins: {alreadyLoaded}, {currentLevel}");
-                }
-            }
-
-            Logger.LogInfo($"Loaded AnchorChain V{((BepInPlugin)Attribute.GetCustomAttribute(typeof(AnchorChainLoader), typeof(BepInPlugin))).Version}!");
-        }
-
-
-        private bool Setup()
-        {
-            foreach (var dir in FileManager.Instance.Directories.ToList().ConvertAll(dir => dir.DirectoryInfo)) {
-                _allDirectories.Add(dir);
-            }
-
-            _configPath = Path.Join(Globals._streamingAssetsPath.FullName, "ACConfigs");
-
-            if (!Directory.Exists(_configPath)) {
-                try {
-                    Directory.CreateDirectory(_configPath);
-                    _allDirectories.Add(new DirectoryInfo(_configPath));
-                } catch (Exception ex) {
-                    Logger.LogError($"Failed to create ACConfigs: {ex}");
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-
-        private HashSet<ACPlugin> FindAllPostLoads(ACPlugin plugin, Dictionary<string, (ACPlugin, IAnchorChainMod)> recognizedPlugins, HashSet<ACPlugin> prev)
-        {
-            if (_postLoadsCache.TryGetValue(plugin.GUID, out HashSet<ACPlugin> cachedPostLoads)) {
-                return cachedPostLoads;
-            }
-
-            if (!prev.Add(plugin)) { return [plugin]; }
-
-            HashSet<ACPlugin> allPostLoads = new();
-
-            foreach (string guid in plugin.After) {
-                allPostLoads.UnionWith(FindAllPostLoads(recognizedPlugins[guid].Item1, recognizedPlugins, prev));
-            }
-
-            _postLoadsCache[plugin.GUID] = allPostLoads;
-            return allPostLoads;
-        }
-
-
-        private bool LoadConfigs(ACPlugin pluginData, ACConfig configData, IniHandler userIni, IniHandler defaultIni)
-        {
-            string userPath = FindFile(pluginData.GUID + "_user.ini");
-            string defaultPath = FindFile(pluginData.GUID + ".ini");
-
-            // Any config-using plugin must have a default config
-            if (defaultPath is null) {
-                Logger.LogWarning($"Required reference config file missing: {pluginData.Name} ({pluginData.GUID})");
-                return false;
-            }
-
-            // Make sure user config exists
-            if (userPath is null) {
-                userPath = Path.Join(_configPath, pluginData.GUID + "_user.ini");
-                if (!WriteNewConfig(
-                        pluginData,
-                        userPath,
-                        defaultPath))
-                {
-                    if (configData.Required) {
-                        return false;
-                    }
-                    Logger.LogInfo($"Failed to load config file: {pluginData.Name} ({pluginData.GUID})");
-                    return true;
-                }
-            }
-
-            // Open now-insured configs
-            userIni.open(userPath);
-            defaultIni.open(defaultPath);
-
-            // Ensure config validity
-            if (!ConfigIsRecent(userIni, defaultIni)) {
-                Logger.LogInfo($"Plugin missing section key: {pluginData.Name} ({pluginData.GUID})");
-                if (!WriteNewConfig(pluginData, userPath, defaultPath)) {
-                    if (configData.Required) {
-                        return false;
-                    }
-                    Logger.LogInfo($"Failed to load config file: {pluginData.Name} ({pluginData.GUID})");
-                    return true;
-                }
-            }
-
-            return true;
-        }
-
-
-        private bool ConfigIsRecent(IniHandler userIni, IniHandler defaultIni)
-        {
-            foreach (KeyValuePair<string, Dictionary<string, string>> section in defaultIni.Data) {
-                if (!userIni.Data.ContainsKey(section.Key)) {
-                    return false;
-                }
-
-                foreach (string key in section.Value.Keys) {
-                    if (!userIni.Data[section.Key].ContainsKey(key)) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-
-
-        private bool WriteNewConfig(ACPlugin pluginData, string userPath, string defaultPath)
-        {
-            Logger.LogInfo($"Writing local config file: {pluginData.Name} ({pluginData.GUID})");
-
-            try {
-                File.Copy(defaultPath, userPath, true);
-            } catch (Exception ex) {
-                Logger.LogError($"Failed to create local config file: {pluginData.Name} ({pluginData.GUID}) | {ex.Message}");
-                return false;
-            }
-
-            return true;
-        }
-
-
-        public static string FindFile(string fileName)
-        {
-            foreach (DirectoryInfo dir in _allDirectories) {
-                string path = Path.Join(dir.FullName, fileName);
-                if (File.Exists(path)) return path;
-            }
-
-            return null;
-        }
-    }
-
-
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    public class ACPlugin([NotNull] string guid, string name, string version, string[] before = null, string[] after = null)
-        : Attribute, IEquatable<ACPlugin>, IEquatable<string>
-    {
-        [NotNull] public string GUID { get; } = guid;
-        [NotNull] public string Name { get; } = name ?? "";
-        [NotNull] public Version Version { get; } = new(version ?? "1.0");
-        [NotNull] public HashSet<string> Before { get; } = before is null ? [] : [..before];
-        [NotNull] public HashSet<string> After { get; } = after is null ? [] : [..after];
-        [NotNull] public HashSet<ACDependency> Dependencies { get; internal set; } = new();
-        [NotNull] public HashSet<ACIncompatibility> Incompatibilities { get; internal set;  } = new();
-
-
-        public bool Equals(ACPlugin other) => other is not null && GUID == other.GUID;
-
-
-        public bool Equals(string other) => other is not null && GUID == other;
-
-
-        public override int GetHashCode() => GUID.GetHashCode();
-    }
-
-
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class ACDependency([NotNull] string guid, string min, string max) : Attribute
-    {
-        public string GUID { get; } = guid;
-        public Version MinVersion { get; } = min is null ? null : new Version(min);
-        public Version MaxVersion { get; } = max is null ? null : new Version(max);
-
-
-        public bool Contains([NotNull] Version version) =>
-            (MinVersion is null || version >= MinVersion) && (MaxVersion is null || version <= MaxVersion);
-    }
-
-
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class ACIncompatibility([NotNull] string guid) : Attribute
-    {
-        public string GUID { get; } = guid;
-    }
-
-
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    public class ACConfig(bool required = false) : Attribute
-    {
-        public bool Required { get; } = required;
-    }
-
-
-    public interface IAnchorChainMod
-    {
-        public void TriggerEntryPoint();
-    }
+	private static Dictionary<string, HashSet<ACPlugin>> _postLoadsCache = new();
+	private static HashSet<DirectoryInfo> _allDirectories = new();
+	private static string _configPath = string.Empty;
+
+
+	public void LoadPlugins()
+	{
+		Dictionary<string, (ACPlugin, IAnchorChainMod)> recognizedPlugins = new();
+		IniHandler userIni = new();
+		IniHandler defaultIni = new();
+
+		if (!Setup()) {
+			Logger.LogError($"Anchor Chain setup failed, aborting load.");
+			return;
+		}
+
+		// First pass, registering plugin classes, configs, dependencies, and plugins to preload
+		foreach (DirectoryInfo dir in _allDirectories) {
+			string possiblePath = Path.Combine(dir.FullName);
+
+			string[] dllFiles = Directory.GetFiles(possiblePath, "*.dll", SearchOption.AllDirectories);
+
+			foreach (string asmPath in dllFiles) {
+				try {
+					Assembly loaded = Assembly.LoadFile(asmPath);
+					Logger.LogInfo("Loaded assembly " + loaded.FullName);
+
+					foreach (Type plugin in (from x in loaded.GetExportedTypes() where x.GetInterfaces().Contains(typeof(IAnchorChainMod)) select x))
+					{
+						// All valid plugins should be annotated with ACPlugin
+						ACPlugin pluginData = (ACPlugin)Attribute.GetCustomAttribute(plugin, typeof(ACPlugin));
+						if (pluginData is null) continue;
+
+						ACConfig configData = (ACConfig)Attribute.GetCustomAttribute(plugin, typeof(ACConfig));
+
+						if (configData is not null && !LoadConfigs(pluginData, configData, userIni, defaultIni)) continue;
+
+						// Set dependencies and incompatibilities
+						pluginData.Dependencies =
+							new(Attribute.GetCustomAttributes(plugin, typeof(ACDependency)).Cast<ACDependency>() ?? []);
+						pluginData.Incompatibilities =
+							new(Attribute.GetCustomAttributes(plugin, typeof(ACIncompatibility)).Cast<ACIncompatibility>() ?? []);
+
+						// Ensure all preloads and postloads are dependencies
+						pluginData.Dependencies.UnionWith(pluginData.Before.Select(x => new ACDependency(x, null, null)));
+						pluginData.Dependencies.UnionWith(pluginData.After.Select(x => new ACDependency(x, null, null)));
+
+						if (!recognizedPlugins.TryAdd(pluginData.GUID, (pluginData, (IAnchorChainMod)Activator.CreateInstance(plugin)))) {
+							Logger.LogWarning($"Attempted to load a duplicate plugin: {pluginData.Name} ({pluginData.GUID})");
+						}
+					}
+				}
+				catch (Exception ex) {
+					Logger.LogWarning("Error loading assembly at path " + asmPath + ": " + ex);
+				}
+			}
+		}
+
+		// Ensure all dependencies are met, and remove plugins missing dependencies
+		while (true) {
+			HashSet<ACPlugin> toRemove = new();
+
+			foreach ((ACPlugin pluginData, IAnchorChainMod _) in recognizedPlugins.Values) {
+				foreach (ACDependency dependency in pluginData.Dependencies) {
+					if (!recognizedPlugins.ContainsKey(dependency.GUID)) {
+						Logger.LogWarning($"Skipping mod \"{pluginData.Name}\" ({pluginData.GUID}); missing dependency \"{dependency.GUID}\"");
+						toRemove.Add(pluginData);
+						break;
+					}
+					if (!dependency.Contains(recognizedPlugins[dependency.GUID].Item1.Version)) {
+						Logger.LogWarning($"Skipping mod \"{pluginData.Name}\" ({pluginData.GUID}); mis-versioned dependency \"{dependency.GUID}\"");
+						toRemove.Add(pluginData);
+						break;
+					}
+				}
+
+				foreach (ACIncompatibility incompatibility in pluginData.Incompatibilities) {
+					if (recognizedPlugins.ContainsKey(incompatibility.GUID)) {
+						Logger.LogWarning($"Skipping mod \"{pluginData.Name}\" ({pluginData.GUID}); detected incompatible mod \"{incompatibility.GUID}\"");
+					}
+					toRemove.Add(pluginData);
+					break;
+				}
+			}
+
+			if (toRemove.Count == 0) {
+				break;
+			}
+
+			foreach (ACPlugin pluginData in toRemove) {
+				recognizedPlugins.Remove(pluginData.GUID);
+			}
+		}
+
+		// Cast all preloads to postloads and postloads to preloads
+		foreach ((ACPlugin pluginData, IAnchorChainMod _) in recognizedPlugins.Values) {
+			foreach (string plugin in pluginData.Before) {
+				recognizedPlugins[plugin].Item1.After.Add(pluginData.GUID);
+			}
+
+			foreach (string plugin in pluginData.After) {
+				recognizedPlugins[plugin].Item1.Before.Add(pluginData.GUID);
+			}
+		}
+
+		// Screen for circular post loads
+		bool circularLoad = false;
+		foreach ((ACPlugin pluginData, IAnchorChainMod _) in recognizedPlugins.Values) {
+			HashSet<ACPlugin> postLoads = FindAllPostLoads(pluginData, recognizedPlugins, new());
+			if (postLoads.Contains(pluginData)) {
+				Logger.LogError($"Aborting chainload; circular load order chain detected: {postLoads}");
+				circularLoad = true;
+			}
+		}
+		if (circularLoad) { return; }
+
+		// Get first "level" of plugins with no preloads
+		HashSet<string> currentLevel = (from x in recognizedPlugins.Values where x.Item1.After.Count == 0 select x.Item1.GUID).ToHashSet() ?? new();
+		HashSet<string> alreadyLoaded = new();
+
+		while (true) {
+			if (currentLevel.Count == 0) { break; }
+
+			bool loadedOne = false;
+			HashSet<string> toLoad = new();
+			foreach (string guid in currentLevel) {
+				(ACPlugin pluginData, IAnchorChainMod plugin) = recognizedPlugins[guid];
+				if (pluginData.After.IsSubsetOf(alreadyLoaded)) {
+					try {
+						plugin.TriggerEntryPoint();
+						Logger.LogInfo($"Loaded plugin {pluginData.Name} ({pluginData.GUID})");
+						toLoad.UnionWith(pluginData.Before);
+						alreadyLoaded.Add(pluginData.GUID);
+						loadedOne = true;
+					}
+					catch (Exception e) {
+						Logger.LogError($"Error loading plugin {pluginData.Name} ({pluginData.GUID}): {e}");
+					}
+				}
+			}
+
+			currentLevel.UnionWith(toLoad);
+			currentLevel.RemoveWhere(x => alreadyLoaded.Contains(x));
+
+			if (!loadedOne) {
+				Logger.LogError($"Aborting chainload; unable to load any more plugins: {alreadyLoaded}, {currentLevel}");
+			}
+		}
+
+		Logger.LogInfo($"Loaded AnchorChain V{((BepInPlugin)Attribute.GetCustomAttribute(typeof(AnchorChainLoader), typeof(BepInPlugin))).Version}!");
+	}
+
+
+	private bool Setup()
+	{
+		foreach (var dir in FileManager.Instance.Directories.ToList().ConvertAll(dir => dir.DirectoryInfo)) {
+			_allDirectories.Add(dir);
+		}
+
+		_configPath = Path.Join(Globals._streamingAssetsPath.FullName, "ACConfigs");
+
+		if (!Directory.Exists(_configPath)) {
+			try {
+				Directory.CreateDirectory(_configPath);
+				_allDirectories.Add(new DirectoryInfo(_configPath));
+			} catch (Exception ex) {
+				Logger.LogError($"Failed to create ACConfigs: {ex}");
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+
+	private HashSet<ACPlugin> FindAllPostLoads(ACPlugin plugin, Dictionary<string, (ACPlugin, IAnchorChainMod)> recognizedPlugins, HashSet<ACPlugin> prev)
+	{
+		if (_postLoadsCache.TryGetValue(plugin.GUID, out HashSet<ACPlugin> cachedPostLoads)) {
+			return cachedPostLoads;
+		}
+
+		if (!prev.Add(plugin)) { return [plugin]; }
+
+		HashSet<ACPlugin> allPostLoads = new();
+
+		foreach (string guid in plugin.After) {
+			allPostLoads.UnionWith(FindAllPostLoads(recognizedPlugins[guid].Item1, recognizedPlugins, prev));
+		}
+
+		_postLoadsCache[plugin.GUID] = allPostLoads;
+		return allPostLoads;
+	}
+
+
+	private bool LoadConfigs(ACPlugin pluginData, ACConfig configData, IniHandler userIni, IniHandler defaultIni)
+	{
+		string userPath = FindFile(pluginData.GUID + "_user.ini");
+		string defaultPath = FindFile(pluginData.GUID + ".ini");
+
+		// Any config-using plugin must have a default config
+		if (defaultPath is null) {
+			Logger.LogWarning($"Required reference config file missing: {pluginData.Name} ({pluginData.GUID})");
+			return false;
+		}
+
+		// Make sure user config exists
+		if (userPath is null) {
+			userPath = Path.Join(_configPath, pluginData.GUID + "_user.ini");
+			if (!WriteNewConfig(
+					pluginData,
+					userPath,
+					defaultPath))
+			{
+				if (configData.Required) {
+					return false;
+				}
+				Logger.LogInfo($"Failed to load config file: {pluginData.Name} ({pluginData.GUID})");
+				return true;
+			}
+		}
+
+		// Open now-insured configs
+		userIni.open(userPath);
+		defaultIni.open(defaultPath);
+
+		// Ensure config validity
+		if (!ConfigIsRecent(userIni, defaultIni)) {
+			Logger.LogInfo($"Plugin missing section key: {pluginData.Name} ({pluginData.GUID})");
+			if (!WriteNewConfig(pluginData, userPath, defaultPath)) {
+				if (configData.Required) {
+					return false;
+				}
+				Logger.LogInfo($"Failed to load config file: {pluginData.Name} ({pluginData.GUID})");
+				return true;
+			}
+		}
+
+		return true;
+	}
+
+
+	private bool ConfigIsRecent(IniHandler userIni, IniHandler defaultIni)
+	{
+		foreach (KeyValuePair<string, Dictionary<string, string>> section in defaultIni.Data) {
+			if (!userIni.Data.ContainsKey(section.Key)) {
+				return false;
+			}
+
+			foreach (string key in section.Value.Keys) {
+				if (!userIni.Data[section.Key].ContainsKey(key)) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+
+	private bool WriteNewConfig(ACPlugin pluginData, string userPath, string defaultPath)
+	{
+		Logger.LogInfo($"Writing local config file: {pluginData.Name} ({pluginData.GUID})");
+
+		try {
+			File.Copy(defaultPath, userPath, true);
+		} catch (Exception ex) {
+			Logger.LogError($"Failed to create local config file: {pluginData.Name} ({pluginData.GUID}) | {ex.Message}");
+			return false;
+		}
+
+		return true;
+	}
+
+
+	public static string FindFile(string fileName)
+	{
+		foreach (DirectoryInfo dir in _allDirectories) {
+			string path = Path.Join(dir.FullName, fileName);
+			if (File.Exists(path)) return path;
+		}
+
+		return null;
+	}
+}
+
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class ACPlugin([NotNull] string guid, string name, string version, string[] before = null, string[] after = null)
+	: Attribute, IEquatable<ACPlugin>, IEquatable<string>
+{
+	[NotNull] public string GUID { get; } = guid;
+	[NotNull] public string Name { get; } = name ?? "";
+	[NotNull] public Version Version { get; } = new(version ?? "1.0");
+	[NotNull] public HashSet<string> Before { get; } = before is null ? [] : [..before];
+	[NotNull] public HashSet<string> After { get; } = after is null ? [] : [..after];
+	[NotNull] public HashSet<ACDependency> Dependencies { get; internal set; } = new();
+	[NotNull] public HashSet<ACIncompatibility> Incompatibilities { get; internal set;  } = new();
+
+
+	public bool Equals(ACPlugin other) => other is not null && GUID == other.GUID;
+
+
+	public bool Equals(string other) => other is not null && GUID == other;
+
+
+	public override int GetHashCode() => GUID.GetHashCode();
+}
+
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class ACDependency([NotNull] string guid, string min, string max) : Attribute
+{
+	public string GUID { get; } = guid;
+	public Version MinVersion { get; } = min is null ? null : new Version(min);
+	public Version MaxVersion { get; } = max is null ? null : new Version(max);
+
+
+	public bool Contains([NotNull] Version version) =>
+		(MinVersion is null || version >= MinVersion) && (MaxVersion is null || version <= MaxVersion);
+}
+
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class ACIncompatibility([NotNull] string guid) : Attribute
+{
+	public string GUID { get; } = guid;
+}
+
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class ACConfig(bool required = false) : Attribute
+{
+	public bool Required { get; } = required;
+}
+
+
+public interface IAnchorChainMod
+{
+	public void TriggerEntryPoint();
 }

--- a/AnchorChain/Main.cs
+++ b/AnchorChain/Main.cs
@@ -237,7 +237,6 @@ public class AnchorChainLoader : BaseUnityPlugin, Preloader.IPluginLoader
 
 		// Ensure config validity
 		foreach ((string sectionName, Dictionary<string, string> section) in defaultIni.Data) {
-			Logger.LogDebug(sectionName);
 			if (ReservedSectionKeys.Contains(sectionName)) continue;
 
 			if (!userIni.doesSectionExist(sectionName)) {

--- a/AnchorChain/Main.cs
+++ b/AnchorChain/Main.cs
@@ -237,6 +237,7 @@ public class AnchorChainLoader : BaseUnityPlugin, Preloader.IPluginLoader
 
 		// Ensure config validity
 		foreach ((string sectionName, Dictionary<string, string> section) in defaultIni.Data) {
+			Logger.LogDebug(sectionName);
 			if (ReservedSectionKeys.Contains(sectionName)) continue;
 
 			if (!userIni.doesSectionExist(sectionName)) {
@@ -254,9 +255,11 @@ public class AnchorChainLoader : BaseUnityPlugin, Preloader.IPluginLoader
 
 		// Process any config commands
 		if (!defaultIni.readValue("AnchorChain.State", "hasReset", false)) {
-			foreach ((string section, string keys) in defaultIni.GetSectionKeyValues("AnchorChain.ResetValues")) {
-				foreach (string key in keys.Split(",")) {
-					userIni.writeValue(section, key, defaultIni.readValue(section, key, ""));
+			if (defaultIni.doesSectionExist("AnchorChain.ResetValues")) {
+				foreach ((string section, string keys) in defaultIni.GetSectionKeyValues("AnchorChain.ResetValues")) {
+					foreach (string key in keys.Split(",")) {
+						userIni.writeValue(section, key, defaultIni.readValue(section, key, ""));
+					}
 				}
 			}
 			defaultIni.writeValue("AnchorChain.State", "hasReset", true);
@@ -326,7 +329,7 @@ public class ACIncompatibility([NotNull] string guid) : Attribute
 
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-public class ACConfig(bool required = false) : Attribute
+public class ACConfig(bool required = true) : Attribute
 {
 	public bool Required { get; } = required;
 }

--- a/AnchorChain/Main.cs
+++ b/AnchorChain/Main.cs
@@ -190,8 +190,7 @@ namespace AnchorChain
 
         private HashSet<ACPlugin> FindAllPostLoads(ACPlugin plugin, Dictionary<string, (ACPlugin, IAnchorChainMod)> recognizedPlugins, HashSet<ACPlugin> prev)
         {
-            HashSet<ACPlugin> cachedPostLoads = new();
-            if (_postLoadsCache.TryGetValue(plugin.GUID, out cachedPostLoads)) {
+            if (_postLoadsCache.TryGetValue(plugin.GUID, out HashSet<ACPlugin> cachedPostLoads)) {
                 return cachedPostLoads;
             }
 
@@ -288,7 +287,7 @@ namespace AnchorChain
         }
 
 
-        private string FindFile(string fileName)
+        public static string FindFile(string fileName)
         {
             foreach (DirectoryInfo dir in _allDirectories) {
                 string path = Path.Join(dir.FullName, fileName);

--- a/Dll/.gitignore
+++ b/Dll/.gitignore
@@ -1,1 +1,2 @@
 Seapower-Scripts.dll
+Noesis.NoesisGUI.dll


### PR DESCRIPTION
This pr introduces a new attribute, ACConfig, to Anchor Chain. It allows for user-editable configs that modders can purposely reset from their updates and are guaranteed to hold all required values. This is a backwards-compatible feature.